### PR TITLE
[KAIZEN-0] La til ekplisitt rapportering av feilmeldinger fra frontend

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -13,6 +13,14 @@ PromisePolyfill.polyfill();
 
 const injectRegex = /\{([^}]+)\}/g;
 
+function rapporterFeilmelding(error) {
+    window.frontendlogger.error({
+        errorname: error.name,
+        message: error.message,
+        error: error.toString()
+    });
+}
+
 function finnElementer() {
     return {
         overskrift: document.querySelector('#overskrift'),
@@ -59,6 +67,8 @@ function render() {
 
 function renderFeilmelding(err) {
     console.error(err); // eslint-disable-line no-console
+    rapporterFeilmelding(err);
+
     const { overskrift, ingress, lenke } = finnElementer();
     overskrift.innerText = 'Oops';
     overskrift.classList.remove('hode-advarsel');
@@ -79,7 +89,7 @@ function getConfigparams(params) {
         if(configparams[key] === undefined) {
             delete configparams[key]
         }
-    })
+    });
     return configparams;
 }
 
@@ -119,5 +129,10 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
     readyBound = true;
-    init();
+    try {
+        init();
+    } catch (error) {
+        rapporterFeilmelding(error);
+        throw error;
+    }
 });


### PR DESCRIPTION
Vi ser en del innmeldte saker til brukerstøtte, hvor brukere stopper
opp i innloggingsinfo med en evig spinner. Kibana gir masse "Script Error", som kan være forårsaket av andre script-ressurser (e.g hode/fot), men for å eliminere
mulige årsaker legges det til litt mer logging i ett håp om at vi skal
finne ut hvorfor noen brukere aldri kommer forbi innloggingsinfo.