### PR TITLE
[KAIZEN-0] Passer på at feilmelding blir vist til bruker.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -75,6 +75,8 @@ function renderFeilmelding(err) {
     overskrift.classList.add('hode-feil');
     ingress.innerText = 'Det skjedde en ukjent feil.';
     lenke.style.display = 'none';
+
+    toggleSpinner();
 }
 
 function toggleSpinner() {


### PR DESCRIPTION
Tidligere løsning hadde følgende kode for å sikre visning av feilmeldingen (se stash).
```
    .then(render)
    .catch(renderFeilmelding)
    .then(toggleSpinner);
```

I Naisifiseringen har siste `.then(toggleSpinner)` blitt borte, og
ved feil blir det derfor stående en evig spinner.

Har vært litt flere endringer i spill ved naisifiseringen, så la til `toggleSpinner` som en del av `renderFeilmelding` for å sikre at den alltid blir vist.