### PR TITLE
Riktig footer med den nye dekoratøren

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM navikt/pus-decorator
 
 ENV APPLICATION_NAME=innloggingsinfo
 ENV CONTEXT_PATH=innloggingsinfo
+ENV FOOTER_TYPE=WITH_ALPHABET
 COPY ./build /app
 
 ENV PORT=8080


### PR DESCRIPTION
Bruker standard footer med den nye dekoratøren og ikke den trimmede slimfit varianten.

PB-404. Innloggingsinfo: Sette rett footer i ny dekoratør.