### PR TITLE
Fikser deploy til personbruker ved å bruke isAlive på readiness

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -22,7 +22,7 @@ spec:
     enabled: true
     path: innloggingsinfo/internal/metrics
   readiness:
-    path: innloggingsinfo/internal/isReady
+    path: innloggingsinfo/internal/isAlive
     port: 8080
     initialDelay: 10
   replicas:


### PR DESCRIPTION
Deploy til personbruker feiler fordi isReady svarer med 503 Service Unavailable. En fiks på det kan være å bruke isAlive når Nais sjekker readiness.